### PR TITLE
#4 - Add CourseUser scaffold.

### DIFF
--- a/app/controllers/course_users_controller.rb
+++ b/app/controllers/course_users_controller.rb
@@ -1,0 +1,2 @@
+class CourseUsersController < ApplicationController
+end

--- a/app/helpers/course_users_helper.rb
+++ b/app/helpers/course_users_helper.rb
@@ -1,0 +1,2 @@
+module CourseUsersHelper
+end

--- a/app/models/course_user.rb
+++ b/app/models/course_user.rb
@@ -1,0 +1,5 @@
+class CourseUser
+  include Mongoid::Document
+  embedded_in :user
+  embedded_in :course
+end

--- a/test/controllers/course_users_controller_test.rb
+++ b/test/controllers/course_users_controller_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class CourseUsersControllerTest < ActionController::TestCase
+  setup do
+    @course_user = course_users(:one)
+  end
+
+  test "should get index" do
+    get :index
+    assert_response :success
+    assert_not_nil assigns(:course_users)
+  end
+
+  test "should get new" do
+    get :new
+    assert_response :success
+  end
+
+  test "should create course_user" do
+    assert_difference('CourseUser.count') do
+      post :create, course_user: { course_id: @course_user.course_id, user_id: @course_user.user_id }
+    end
+
+    assert_redirected_to course_user_path(assigns(:course_user))
+  end
+
+  test "should show course_user" do
+    get :show, id: @course_user
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get :edit, id: @course_user
+    assert_response :success
+  end
+
+  test "should update course_user" do
+    patch :update, id: @course_user, course_user: { course_id: @course_user.course_id, user_id: @course_user.user_id }
+    assert_redirected_to course_user_path(assigns(:course_user))
+  end
+
+  test "should destroy course_user" do
+    assert_difference('CourseUser.count', -1) do
+      delete :destroy, id: @course_user
+    end
+
+    assert_redirected_to course_users_path
+  end
+end

--- a/test/fixtures/course_users.yml
+++ b/test/fixtures/course_users.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 
+  course_id: 
+
+two:
+  user_id: 
+  course_id: 

--- a/test/models/course_user_test.rb
+++ b/test/models/course_user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CourseUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
There is a odd thing in here, the `CourseUser` model is not in the _admin interface_, maybe because this is just m2m model for `Course` and `User`, but i dont know really.
